### PR TITLE
experiment: use std::unordered_map in Looper instead of std::map

### DIFF
--- a/src/include/core/looper.h
+++ b/src/include/core/looper.h
@@ -15,7 +15,7 @@
 #include <atomic>
 #include <functional>
 #include <future>  // NOLINT
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <mutex>  // NOLINT
 
@@ -59,7 +59,7 @@ class Looper {
  private:
   std::unique_ptr<Poller> poller_;
   std::mutex mtx_;
-  std::map<int, std::unique_ptr<Connection>> connections_;
+  std::unordered_map<int, std::unique_ptr<Connection>> connections_;
   bool exit_{false};
 };
 }  // namespace TURTLE_SERVER


### PR DESCRIPTION
#22 