### PR TITLE
refactor: cache cold-miss optimization

### DIFF
--- a/src/http/response.cpp
+++ b/src/http/response.cpp
@@ -75,13 +75,6 @@ void Response::Serialize(std::vector<unsigned char> &buffer) { // NOLINT
   str_stream << CRLF;
   std::string response_head = str_stream.str();
   buffer.insert(buffer.end(), response_head.begin(), response_head.end());
-  if (resource_url_.has_value() && should_transfer_content_) {
-    LoadFile(resource_url_.value(), buffer);
-  }
-}
-
-void Response::SetShouldTransferContent(bool should_transfer_content) noexcept {
-  should_transfer_content_ = should_transfer_content;
 }
 
 auto Response::GetHeaders() -> std::vector<Header> { return headers_; }

--- a/src/include/http/response.h
+++ b/src/include/http/response.h
@@ -39,9 +39,8 @@ class Response {
   Response(const std::string &status_code, bool should_close,
            std::optional<std::string> resource_url);
 
+  /* no content, content should separately be loaded */
   void Serialize(std::vector<unsigned char> &buffer);  // NOLINT
-
-  void SetShouldTransferContent(bool should_transfer_content) noexcept;
 
   auto GetHeaders() -> std::vector<Header>;
 
@@ -50,7 +49,6 @@ class Response {
 
  private:
   std::string status_line_;
-  bool should_transfer_content_{true};
   bool should_close_;
   std::vector<Header> headers_;
   std::optional<std::string> resource_url_;


### PR DESCRIPTION
#32 

when **1st** cold-miss on a file, after loading the file from disk once, directly try store in cache and insert into response_buf.

Old version takes **2 disk I/O** to load the file twice for cache and response_buf, not efficient