### PR TITLE
Timer debug

### DIFF
--- a/src/core/looper.cpp
+++ b/src/core/looper.cpp
@@ -54,10 +54,17 @@ void Looper::AddConnection(std::unique_ptr<Connection> new_conn) {
 }
 
 auto Looper::RefreshConnection(int fd) noexcept -> bool {
+  if (!use_timer_) {
+      return false;
+  }
   std::unique_lock<std::mutex> lock(mtx_);
   auto it = timers_mapping_.find(fd);
   if (use_timer_ && it != timers_mapping_.end()) {
-    return timer_.RefreshSingleTimer(it->second, timer_expiration_);
+    auto new_timer = timer_.RefreshSingleTimer(it->second, timer_expiration_);
+    if (new_timer != nullptr) {
+        timers_mapping_.insert({fd, new_timer});
+    }
+    return true;
   }
   return false;
 }

--- a/src/include/core/timer.h
+++ b/src/include/core/timer.h
@@ -80,7 +80,7 @@ class Timer {
 
   auto RemoveSingleTimer(SingleTimer *single_timer) noexcept -> bool;
 
-  auto RefreshSingleTimer(SingleTimer *single_timer, uint64_t expire_from_now) noexcept -> bool;
+  auto RefreshSingleTimer(SingleTimer *single_timer, uint64_t expire_from_now) noexcept -> Timer::SingleTimer *;
 
   auto NextExpireTime() const noexcept -> uint64_t;
 


### PR DESCRIPTION
When a client `Connection` messages and the timer expiration for it happens in the same round of `Epoll`, the pointers for that conneciton is deleted and becomes invalid